### PR TITLE
Adds test coverage for alpine linux.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,11 +16,12 @@ before_script:
   - export CHROME_PATH="$(pwd)/chrome-linux/chrome"
   - sh -e /etc/init.d/xvfb start
   - sleep 3 # wait for xvfb to boot
-  - yarn build
+  - yarn run build
+  - yarn run build-docker
 script:
-  - yarn test-formatting
-  - yarn test
-  - yarn docker-test
+  - yarn run test-formatting
+  - yarn run test
+  - yarn run docker-test
 after_success:
   - yarn run coverage
 # - (send to coveralls)

--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ before_script:
 script:
   - yarn test-formatting
   - yarn test
+  - yarn docker-test
 after_success:
   - yarn run coverage
 # - (send to coveralls)

--- a/package.json
+++ b/package.json
@@ -4,6 +4,8 @@
   "scripts": {
     "build": "tsc",
     "dev": "tsc -w",
+    "build-docker": "docker build -t chrome-launcher:test -f test/Dockerfile .",
+    "docker-test": "docker run --privileged -t chrome-launcher:test",
     "test": "mocha --require ts-node/register --reporter=dot test/**/*-test.ts --timeout=10000",
     "coverage": "nyc yarn test && nyc report --reporter=text-lcov > lcov.info",
     "test-formatting": "test/check-formatting.sh",

--- a/test/Dockerfile
+++ b/test/Dockerfile
@@ -1,0 +1,25 @@
+FROM node:alpine
+
+WORKDIR /app
+
+#install chromium/yarn
+RUN apk --update --no-cache add chromium xvfb curl bash binutils tar \
+    && curl -o- -L https://yarnpkg.com/install.sh | bash \
+    && apk del curl tar binutils
+
+COPY package.json .
+COPY yarn.lock .
+
+ENV DISPLAY :99.0
+ENV CHROME_PATH /usr/lib/chrome
+
+#install
+RUN yarn --frozen-lockfile
+
+#copy rest of files in
+COPY . .
+
+#build everything
+RUN yarn build
+
+ENTRYPOINT [ "/bin/bash", "-c", "yarn test-formatting && yarn test" ]


### PR DESCRIPTION
I've gone ahead and added some alpine test coverage using travis-ci and docker to build an alpine image and test the run in there. It may need some tweaks/changes (chromium appears to be in /usr/lib/chrome, but it may not be functionality correctly), but this should be a good start to determine if this is working correctly.

See the following docker test:
![image](https://user-images.githubusercontent.com/4589840/32625838-69061d3c-c55b-11e7-85b9-d112c6a27636.png)

See a sample build output of it failing [here](https://travis-ci.org/danbopes/chrome-launcher/jobs/299823717).